### PR TITLE
Fix a too broad usage of strtolower in the autoloaders

### DIFF
--- a/elanta-builder/autoloader.php
+++ b/elanta-builder/autoloader.php
@@ -72,7 +72,7 @@ class Autoloader {
 					'-',
 					DIRECTORY_SEPARATOR,
 				),
-				strtolower($relative_class_name)
+				strtolower( $relative_class_name )
 			);
 
 			$filename = ELANTA_BUILDER_PATH . $filename . '.php';

--- a/elanta-builder/autoloader.php
+++ b/elanta-builder/autoloader.php
@@ -65,23 +65,19 @@ class Autoloader {
 			$filename = ELANTA_BUILDER_PATH . self::$classes_map[ $relative_class_name ];
 		} else {
 
-			$filename = strtolower(
-				preg_replace(
-					array( '/([a-z])([A-Z])/', '/_/', '/\\\/' ),
-					array(
-						'$1-$2',
-						'-',
-						DIRECTORY_SEPARATOR,
-					),
-					$relative_class_name
-				)
+			$filename = preg_replace(
+				array( '/([a-z])([A-Z])/', '/_/', '/\\\/' ),
+				array(
+					'$1-$2',
+					'-',
+					DIRECTORY_SEPARATOR,
+				),
+				strtolower($relative_class_name)
 			);
 
 			$filename = ELANTA_BUILDER_PATH . $filename . '.php';
 
 		}
-
-		$filename = strtolower( $filename );
 
 		if ( is_readable( $filename ) ) {
 			require $filename;

--- a/src/autoloader.php
+++ b/src/autoloader.php
@@ -127,7 +127,7 @@ class Autoloader {
 			// replace the namespace prefix with the base directory,
 			// replace namespace separators with directory separators
 			// in the relative class name, append with .php.
-			$file = $base_dir . str_replace( '\\', '/', strtolower($relative_class )) . '.php';
+			$file = $base_dir . str_replace( '\\', '/', strtolower( $relative_class ) ) . '.php';
 
 			// if the mapped file exists, require it.
 			if ( $this->require_file( $file ) ) {

--- a/src/autoloader.php
+++ b/src/autoloader.php
@@ -127,10 +127,10 @@ class Autoloader {
 			// replace the namespace prefix with the base directory,
 			// replace namespace separators with directory separators
 			// in the relative class name, append with .php.
-			$file = $base_dir . str_replace( '\\', '/', $relative_class ) . '.php';
+			$file = $base_dir . str_replace( '\\', '/', strtolower($relative_class )) . '.php';
 
 			// if the mapped file exists, require it.
-			if ( $this->require_file( strtolower( $file ) ) ) {
+			if ( $this->require_file( $file ) ) {
 				// yes, we're done.
 				return $file;
 			}


### PR DESCRIPTION
Fixes #2 (which can cause the plugin to fail to load in OSes with case-sensitive paths).

This strtolower on line 84 seems useless when the corresponding class file is already declared in $classes_map line 29, unless doubting the mapping.
The use of strtolower for cases not in $classes_map line 68 could also cause the same problem, so maybe it would be better to move it to line 76 to only:
```
$filename = preg_replace(
	array( '/([a-z])([A-Z])/', '/_/', '/\\\/' ),
	array(
		'$1-$2',
		'-',
		DIRECTORY_SEPARATOR,
	),
	strtolower($relative_class_name)
);
```


A similar issue lies in _src/autoloader.php_, lines 130-133:
```
$file = $base_dir . str_replace( '\\', '/', $relative_class ) . '.php';

// if the mapped file exists, require it.
if ( $this->require_file( strtolower( $file ) ) ) {
```

The following worked for me:
```
$file = $base_dir . str_replace( '\\', '/', strtolower( $relative_class ) ) . '.php';

// if the mapped file exists, require it.
if ( $this->require_file( $file ) ) {
```

(EDIT: Split the issue part in its own issue)